### PR TITLE
Added Fix: Preventing some easy dupes

### DIFF
--- a/src/main/java/com/danlegt/bettershulkers/BetterShulkers.java
+++ b/src/main/java/com/danlegt/bettershulkers/BetterShulkers.java
@@ -6,12 +6,18 @@ import org.bukkit.plugin.java.JavaPlugin;
 
 public final class BetterShulkers extends JavaPlugin {
 
+    private static BetterShulkers INSTANCE;
+
     @Override
     public void onEnable() {
         // Register the drop event
+        INSTANCE = this;
         getServer().getPluginManager().registerEvents(new ShulkerDropEvent(), this);
         // Init bStats
         Metrics metrics = new Metrics(this, 19672);
     }
 
+    public static BetterShulkers getINSTANCE() {
+        return INSTANCE;
+    }
 }

--- a/src/main/java/com/danlegt/bettershulkers/Events/ShulkerDropEvent.java
+++ b/src/main/java/com/danlegt/bettershulkers/Events/ShulkerDropEvent.java
@@ -1,11 +1,16 @@
 package com.danlegt.bettershulkers.Events;
 
+import com.danlegt.bettershulkers.BetterShulkers;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.SoundCategory;
 import org.bukkit.block.ShulkerBox;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.inventory.InventoryInteractEvent;
@@ -17,52 +22,93 @@ import org.bukkit.inventory.meta.ItemMeta;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 public class ShulkerDropEvent implements Listener {
 
     public static List<Inventory> shulkerInventoryBinds = new ArrayList<>();
+    //ArrayList to prevent players from opening and placing Shulkers at the same time to stop duping
+    private static ArrayList<Player> blockedPlayers = new ArrayList<>();
+    private static ArrayList<Player> openShulkers = new ArrayList<>();
 
     // React each time a shulker is dropped
-    @EventHandler
+    @EventHandler(priority = EventPriority.LOWEST)
     public void onShulkerDrop(PlayerDropItemEvent ev) {
         // Get a reference to the player
         var p = ev.getPlayer();
 
         // Check if the player has the required permission to perform the action
-        if ( !p.hasPermission("bettershulkers.shulkerboxaccess") ) {
+        if (!p.hasPermission("bettershulkers.shulkerboxaccess")) {
             return;
         }
 
         // Check if the player is not sneaking
-        if ( !p.isSneaking() ) return;
+        if (!p.isSneaking()) return;
 
         // Get a reference to the dropped item
         var item = ev.getItemDrop().getItemStack();
         // Get the meta of the dropped item
         var meta = item.getItemMeta();
 
-
         // Check if the meta of the item is null, if it is simply ignore this event.
-        if ( meta == null ) return;
+        if (meta == null) return;
 
         // Get the ShulkerBox meta
         var sm = getShulkerMeta(meta);
 
         // Check if the item is a shulker
-        if ( sm == null ) return;
+        if (sm == null) return;
 
         // Get a reference to the inventory
         var inv = sm.getInventory();
         // Mark the inventory as a shulker listener
         shulkerInventoryBinds.add(inv);
 
+        //Prevent player from dropping this Shulker or moving it in inventory
+        openShulkers.add(p);
         // Open the inventory of the shulker for the player
         p.openInventory(inv);
         // Play open sound
         p.playSound(p.getLocation(), Sound.BLOCK_SHULKER_BOX_OPEN, SoundCategory.BLOCKS, 1f, 1.25f);
         // Cancel the throw event
         ev.setCancelled(true);
+        //block placer from placing the same shulker
+        blockedPlayers.add(p);
+
+        Bukkit.getScheduler().runTaskLaterAsynchronously(BetterShulkers.getINSTANCE(), new Runnable() {
+            public void run() {
+                blockedPlayers.remove(p);
+            }
+        }, 1L);
+
+    }
+
+    @EventHandler
+    public void onPlayerDropOpenedShulker(PlayerDropItemEvent ev) {
+        Player p = ev.getPlayer();
+        if (!(openShulkers.contains(p))) return;
+        var item = p.getInventory().getItemInMainHand();
+        if (item.equals(ev.getItemDrop().getItemStack())) ev.setCancelled(true);
+    }
+
+    @EventHandler
+    public void onMoveOpenedShulkers(InventoryClickEvent ev) {
+        if (!(ev.getWhoClicked() instanceof Player p)) return;
+        if(!openShulkers.contains(p)) return;
+        var item = p.getInventory().getItemInMainHand();
+        if (item.equals(ev.getCurrentItem())) ev.setCancelled(true);
+    }
+
+    @EventHandler
+    public void onShulkerPlace(BlockPlaceEvent ev) {
+        Player p = ev.getPlayer();
+        if (!(ev.getBlockPlaced().getState() instanceof ShulkerBox)) return;
+
+        // Check if player is in list containing players that opened shulker 1 tick ago
+        if (blockedPlayers.contains(p)) ev.setCancelled(true);
+
     }
 
     @EventHandler
@@ -70,17 +116,18 @@ public class ShulkerDropEvent implements Listener {
         var inv = ev.getInventory();
         if (!shulkerInventoryBinds.contains(inv)) return;
         var item = ev.getPlayer().getInventory().getItemInMainHand();
-        if ( !(ev.getPlayer() instanceof Player p) ) return;
+        if (!(ev.getPlayer() instanceof Player p)) return;
 
         handleInventoryShananigans(inv, item);
         p.playSound(p.getLocation(), Sound.BLOCK_SHULKER_BOX_OPEN, SoundCategory.BLOCKS, 1f, 1.25f);
+        openShulkers.remove(p);
     }
 
     @EventHandler
     public void onShulkerInventoryClick(InventoryClickEvent ev) {
         var inv = ev.getInventory();
         if (!shulkerInventoryBinds.contains(inv)) return;
-        if ( !(ev.getWhoClicked() instanceof Player p) ) return;
+        if (!(ev.getWhoClicked() instanceof Player p)) return;
         var item = p.getInventory().getItemInMainHand();
 
         handleInventoryShananigans(inv, item);
@@ -90,7 +137,7 @@ public class ShulkerDropEvent implements Listener {
     public void onShulkerInventoryInteract(InventoryInteractEvent ev) {
         var inv = ev.getInventory();
         if (!shulkerInventoryBinds.contains(inv)) return;
-        if ( !(ev.getWhoClicked() instanceof Player p) ) return;
+        if (!(ev.getWhoClicked() instanceof Player p)) return;
         var item = p.getInventory().getItemInMainHand();
 
         handleInventoryShananigans(inv, item);
@@ -116,10 +163,10 @@ public class ShulkerDropEvent implements Listener {
         item.setItemMeta(bsm);
     }
 
-    private static ShulkerBox getShulkerMeta(@Nonnull ItemMeta meta ) {
-        if ( !(meta instanceof BlockStateMeta bsm) ) return null;
+    private static ShulkerBox getShulkerMeta(@Nonnull ItemMeta meta) {
+        if (!(meta instanceof BlockStateMeta bsm)) return null;
         var csm = bsm.getBlockState();
-        if ( !(csm instanceof ShulkerBox sb) ) return null;
+        if (!(csm instanceof ShulkerBox sb)) return null;
 
         return sb;
     }


### PR DESCRIPTION
Added Fix: Before you could place and drop at the same time and you would have a duped inventory open. This is done by preventing the player from placing shulkers for 1 tick
Added Fix: Preventing Player from dropping the shulker or moving it in the inventory while its open. So changes can be applied after InventoryCloseEvent. This is done by basically locking the main hand at the InventoryClickEvent